### PR TITLE
Make the crate no-std compatible

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,7 @@ categories = ["algorithms"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+
+[features]
+default = ["std"]
+std = []

--- a/README.md
+++ b/README.md
@@ -38,3 +38,8 @@ same api.
   - `insertion_sort` does the classic N^2 sorting algorithm
   - `merge_sort` performs an in-place stable sort using an adaptation of the merge sort algorithm provided in the fastutil library
   - `quick_sort` performs an unstable sort using a quick sort algorithm based on the implementation used in Servo
+
+Features
+--------
+
+The `std` feature (enabled by default) adds a `Sortable` impl for `Vec`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,11 @@
 //!
 //!
 
-use std::{cmp::Ordering, ops::Range};
+// Enable `no_std` unless the `std` feature is enabled or the crate is
+// compiled in test mode.
+#![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
+
+use core::{cmp::Ordering, ops::Range};
 
 /// Sortable is defined for types that should be allowed to be sorted.
 pub trait Sortable {
@@ -55,6 +59,7 @@ impl<T: Ord> Sortable for [T] {
 }
 
 /// Vectors of ordered elements are sortable
+#[cfg(feature = "std")]
 impl <T: Ord> Sortable for Vec<T> {
     fn swap(&mut self, i: usize, j: usize) {
         self[..].swap(i, j)


### PR DESCRIPTION
Add the usual `std` feature (enabled by default) to control whether `no_std` is enabled. This is useful for embedded targets that support `core` but not `std`.